### PR TITLE
Unsubscribe screen & endpoint for marketing blasts

### DIFF
--- a/pages/api/unsubscribe.ts
+++ b/pages/api/unsubscribe.ts
@@ -20,7 +20,7 @@ export const unsubFromMarketingBlasts = async (req: NextApiRequest, res: NextApi
         Authorization: `Bearer ${process.env.ADMIN_BEARER_TOKEN}`,
         'content-type': 'application/json',
       },
-      body: JSON.stringify({ userId: undefined }),
+      body: JSON.stringify({ userId: uuid }),
     })
       .then((res) => res.json())
       .then((data) => {

--- a/pages/api/unsubscribe.ts
+++ b/pages/api/unsubscribe.ts
@@ -16,6 +16,7 @@ export const unsubFromMarketingBlasts = async (req: NextApiRequest, res: NextApi
     await fetch(unsubEndpoint, {
       method: 'POST',
       headers: {
+        Authorization: `Bearer ${process.env.ADMIN_BEARER_TOKEN}`,
         'content-type': 'application/json',
       },
       body: JSON.stringify({ userId: uuid }),

--- a/pages/api/unsubscribe.ts
+++ b/pages/api/unsubscribe.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export const unsubFromMarketingBlasts = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { uuid } = req.body;
+  try {
+    if (!uuid) {
+      throw new Error('Missing uuid in body of request, /api/unsubscribe');
+    }
+
+    const unsubEndpoint = `https://${
+      process.env.NEXT_PUBLIC_ENVIRONMENT === 'production'
+        ? 'admin-server.modulz.app'
+        : 'admin-server-develop.modulz-deploys.com'
+    }/unsubscribe/marketing`;
+
+    await fetch(unsubEndpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ userId: uuid }),
+    }).catch((err) => {
+      throw new Error(err);
+    });
+
+    res.status(200).end();
+  } catch (err) {
+    console.error(err);
+    res.status(500).send({ error: 'Unable to unsubscribe from marketing blasts' });
+  }
+};
+
+export default unsubFromMarketingBlasts;

--- a/pages/api/unsubscribe.ts
+++ b/pages/api/unsubscribe.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import fetch from 'node-fetch';
 
 export const unsubFromMarketingBlasts = async (req: NextApiRequest, res: NextApiResponse) => {
   const { uuid } = req.body;
@@ -19,10 +20,17 @@ export const unsubFromMarketingBlasts = async (req: NextApiRequest, res: NextApi
         Authorization: `Bearer ${process.env.ADMIN_BEARER_TOKEN}`,
         'content-type': 'application/json',
       },
-      body: JSON.stringify({ userId: uuid }),
-    }).catch((err) => {
-      throw new Error(err);
-    });
+      body: JSON.stringify({ userId: undefined }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.status !== 200) {
+          throw new Error('Unable to unsubscribe from marketing blasts');
+        }
+      })
+      .catch((err) => {
+        throw new Error(err);
+      });
 
     res.status(200).end();
   } catch (err) {

--- a/pages/unsubscribe.tsx
+++ b/pages/unsubscribe.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect } from 'react';
+import dynamic from 'next/dynamic';
+import { Flex, Text, theme } from '@modulz/radix';
+import { useRouter } from 'next/router';
+
+const Unsubscribe = () => {
+  const router = useRouter();
+  const { uuid } = router.query;
+
+  useEffect(() => {
+    fetch('/api/unsubscribe', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ uuid }),
+    });
+  }, []);
+
+  return (
+    <Flex
+      sx={{
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        pt: '35vh',
+        pb: '40vh',
+        width: '100%',
+        height: '100%',
+      }}
+    >
+      <Text size={8} sx={{ textAlign: 'center', color: theme.colors.green900 }}>
+        You have been successfully unsubscribed
+      </Text>
+    </Flex>
+  );
+};
+
+export default dynamic(() => Promise.resolve(Unsubscribe), {
+  ssr: false,
+});

--- a/pages/unsubscribe.tsx
+++ b/pages/unsubscribe.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
-import dynamic from 'next/dynamic';
-import { Flex, Text, theme } from '@modulz/radix';
+import { Flex, Text } from '@modulz/radix';
 import { useRouter } from 'next/router';
 
 const Unsubscribe = () => {
@@ -17,7 +16,7 @@ const Unsubscribe = () => {
         body: JSON.stringify({ uuid }),
       });
     }
-  }, []);
+  }, [uuid]);
 
   return (
     <Flex
@@ -31,13 +30,11 @@ const Unsubscribe = () => {
         height: '100%',
       }}
     >
-      <Text size={8} sx={{ textAlign: 'center', color: theme.colors.green900 }}>
+      <Text size={8} sx={{ textAlign: 'center', color: 'hsl(148 69% 30.0%)' }}>
         You have been successfully unsubscribed
       </Text>
     </Flex>
   );
 };
 
-export default dynamic(() => Promise.resolve(Unsubscribe), {
-  ssr: false,
-});
+export default Unsubscribe;

--- a/pages/unsubscribe.tsx
+++ b/pages/unsubscribe.tsx
@@ -8,13 +8,15 @@ const Unsubscribe = () => {
   const { uuid } = router.query;
 
   useEffect(() => {
-    fetch('/api/unsubscribe', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-      },
-      body: JSON.stringify({ uuid }),
-    });
+    if (uuid) {
+      fetch('/api/unsubscribe', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ uuid }),
+      });
+    }
   }, []);
 
   return (


### PR DESCRIPTION
Clicking the unsubscribe link in marketing emails will land the user at modulz.app/unsubscribe.  A flag will be placed on their account and they won't receive the marketing emails moving forward.